### PR TITLE
Added expiration-intents and billing retry period

### DIFF
--- a/lib/itunes_receipt_validator/receipt.rb
+++ b/lib/itunes_receipt_validator/receipt.rb
@@ -6,6 +6,11 @@ module ItunesReceiptValidator
   class Receipt
     attr_reader :receipt
     attr_accessor :shared_secret, :request_method
+    attr_accessor :remote
+
+    delegate :in_billing_retry_period?, to: :remote
+    delegate :in_cancelled_billing_retry_period?, to: :remote
+    delegate :expiration_intent, to: :remote
 
     def initialize(receipt, options = {})
       @receipt = receipt


### PR DESCRIPTION
Apple will include information about the intention of an expired subscription like "cancelled" or "billing error". There is also a flag for expired subscriptions where Apple is still trying to renew the subscription. This PR will make it possible to query these parameters when doing a remote-check.