### PR TITLE
Correct cancelled_at mapping

### DIFF
--- a/lib/itunes_receipt_validator/transaction.rb
+++ b/lib/itunes_receipt_validator/transaction.rb
@@ -24,7 +24,7 @@ module ItunesReceiptValidator
                    hash[:original_purchase_date]
       end,
       cancelled_at: proc do |hash|
-        parse_date(hash[:cancelled_date_ms] || hash[:cancelled_date])
+        parse_date(hash[:cancellation_date_ms] || hash[:cancellation_date])
       end,
       expires_at: proc do |hash|
         if hash[:bid]


### PR DESCRIPTION
Cancel-related attributes in iTunes receipts are `cancellation_date_ms` and `cancellation_date`, not `cancelled_date_ms` and `cancelled_date` (https://developer.apple.com/documentation/appstorereceipts/responsebody/latest_receipt_info)